### PR TITLE
cheap-module-source-map

### DIFF
--- a/src/webpack/webpack.dev.config.js
+++ b/src/webpack/webpack.dev.config.js
@@ -23,7 +23,7 @@ module.exports = function (cwd, project) {
 
   return makeConfig({
     // context: cwd,
-    devtool: "eval-source-map",
+    devtool: "cheap-module-source-map",
     //为每个entry增加hot load
     entry: entries,
     output: {


### PR DESCRIPTION
编译出来的index.js更小,  而且报错时提示信息更友好